### PR TITLE
When creating resources in bulk, Clio's APIs respond success even if …

### DIFF
--- a/lib/clio_client/api/crudable.rb
+++ b/lib/clio_client/api/crudable.rb
@@ -40,7 +40,14 @@ module ClioClient
 
       def create_plural(params)
         response = session.post(end_point_url, {plural_resource => params}.to_json)
-        response[plural_resource].map { |resource| data_item(resource) }
+        response[plural_resource].map do |resource|
+          # Errors are presented inline when doing bulk create via the Clio API
+          if resource.key?("errors")
+            resource
+          else
+            data_item(resource)
+          end
+        end
       end
 
     end

--- a/spec/api/crudable_spec.rb
+++ b/spec/api/crudable_spec.rb
@@ -21,12 +21,27 @@ describe ClioClient::Api::Crudable do
     let(:response) do
       { "dummy" => { string: "1" } }
     end
+    let(:inline_error_response) do
+      { "errors" => { "base" => ["Something went wrong"] } }
+    end
 
     it "issues with create request" do
       session.stub(:post).with("test", {"dummy" => params}.to_json).and_return(response)
       record = subject.create(params)
       expect(record).to be_kind_of TestResource
       expect(record.string).to eql "1"
+    end
+
+    context "when errors are returned" do
+      it "should parse them inline" do
+        session.stub(:post).with("test", {"dummies" => [params, params]}.to_json).and_return({"dummies" => [response["dummy"], inline_error_response]})
+        records = subject.create([params, params])
+        expect(records[0]).to be_kind_of TestResource
+        expect(records[0].string).to eql "1"
+
+        expect(records[1]).to be_kind_of Hash
+        expect(records[1]["errors"]["base"][0]).to eql "Something went wrong"
+      end
     end
   end
 


### PR DESCRIPTION
…some of the resources were not created. Errors are rendered inline. Add the raw error response to the created resources array