### PR TITLE
Fix issue 15

### DIFF
--- a/lib/clio_client/http.rb
+++ b/lib/clio_client/http.rb
@@ -1,11 +1,11 @@
 module ClioClient
 
-  class Unauthorized < StandardError; end 
+  class Unauthorized < StandardError; end
   class ResourceNotFound < StandardError; end
   class BadRequest < StandardError; end
   class UnknownResponse < StandardError; end
   class Forbidden < StandardError; end
-  
+
   module Http
 
     def base_uri(path, params = {})
@@ -22,7 +22,7 @@ module ClioClient
     end
 
     def put(path, body = "", parse=true)
-      uri = base_uri("#{api_prefix}/#{path}")        
+      uri = base_uri("#{api_prefix}/#{path}")
       req = Net::HTTP::Put.new(uri.request_uri)
       req.body = body
       req.add_field("Content-Type", "application/json")
@@ -30,13 +30,13 @@ module ClioClient
     end
 
     def multipart_post(path, params, parse = true)
-      uri = base_uri("#{api_prefix}/#{path}")        
+      uri = base_uri("#{api_prefix}/#{path}")
       req = Net::HTTP::Post::Multipart.new(uri.request_uri, params)
       make_api_request(req, uri, parse)
     end
 
     def post(path, body ="", parse = true)
-      uri = base_uri("#{api_prefix}/#{path}")        
+      uri = base_uri("#{api_prefix}/#{path}")
       req = Net::HTTP::Post.new(uri.request_uri)
       req.body = body
       req.add_field("Content-Type", "application/json")
@@ -98,5 +98,5 @@ module ClioClient
     def api_prefix; "/api/v2"; end
 
   end
-  
+
 end

--- a/lib/clio_client/http.rb
+++ b/lib/clio_client/http.rb
@@ -5,6 +5,7 @@ module ClioClient
   class BadRequest < StandardError; end
   class UnknownResponse < StandardError; end
   class Forbidden < StandardError; end
+  class Conflict < StandardError; end
 
   module Http
 
@@ -84,6 +85,8 @@ module ClioClient
         res["Location"]
       when Net::HTTPForbidden
         raise ClioClient::Forbidden.new(res.body)
+      when Net::HTTPConflict
+        raise ClioClient::Conflict.new(res.body)
       else
         raise UnknownResponse.new(res.body)
       end

--- a/lib/clio_client/resource.rb
+++ b/lib/clio_client/resource.rb
@@ -13,7 +13,7 @@ module ClioClient
       end * ", "
       "#{super}(#{attr_list})"
     end
-    
+
     def inspect
       attr_list = self.class.attributes.inject([]) do |a, (attr, opts)|
         if has_attribute?(attr)
@@ -21,7 +21,7 @@ module ClioClient
         else
           a
         end
-      end * ", "      
+      end * ", "
       "#<#{self.class} #{attr_list}>"
     end
 
@@ -50,13 +50,13 @@ module ClioClient
           attr_reader name
           define_method "#{name}=" do |value|
             if options[:readonly] && !instance_variable_get("@#{name}").nil?
-              raise AttributeReadOnly 
+              raise AttributeReadOnly
             end
             write_attribute("#{name}", convert_attribute(value, options))
           end
         end
       end
-      
+
       def inherited(subclass)
         if !self.attributes.nil?
           subclass.attributes = self.attributes
@@ -76,14 +76,14 @@ module ClioClient
             obj = klass.new(attributes, session)
           end
           write_attribute("#{name}", obj)
-        end      
+        end
       end
 
       def has_many_association(name, klass, options = {})
         attr_reader name
         self.attributes[name.intern] = {type: :has_many_association}
         define_method "#{name}=" do |arr|
-          many = arr.collect do |attributes| 
+          many = arr.collect do |attributes|
             if options[:polymorphic]
               obj = polymorphic_object(attributes, options[:accepted_types])
               obj ||= klass.new(attributes, session)
@@ -92,11 +92,11 @@ module ClioClient
             end
           end
           write_attribute(name, many)
-        end      
+        end
       end
-      
+
     end
-      
+
     def ==(o)
       self.class == o.class && !self.id.nil? && self.id != "" && self.id == o.id
     end
@@ -110,7 +110,7 @@ module ClioClient
     def save
       if self.id.nil?
         saved_item = api.create(self.to_params)
-        self.id = saved_item && saved_item.id
+        self.id = saved_item.id if saved_item
         self
       else
         api.update(self.id, self.to_params)
@@ -119,7 +119,7 @@ module ClioClient
     end
 
     def reload
-      raise ResourceNotSaved if self.id.nil?      
+      raise ResourceNotSaved if self.id.nil?
       api.find(self.id)
     end
 
@@ -148,7 +148,7 @@ module ClioClient
       instance_variable_defined?("@#{attr}")
     end
 
-    def paramify(val)      
+    def paramify(val)
       if val.kind_of? ClioClient::Resource
         val.to_params
       elsif val.kind_of? Array
@@ -168,15 +168,15 @@ module ClioClient
         val.kind_of?(Date) ? val : Date.parse(val)
       when :decimal
         val.to_f
-      when :boolean 
+      when :boolean
         val == true || val == "true"
-      when :datetime 
+      when :datetime
         val.kind_of?(DateTime) ? val : DateTime.parse(val)
-      when :datetime 
+      when :datetime
         val.kind_of?(Time) ? val : Time.parse(val)
-      when :foreign_key 
+      when :foreign_key
         (val == "" || val.nil?) ? nil : val.to_i
-      else 
+      else
         val
       end
     end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -7,7 +7,7 @@ describe ClioClient::Resource do
   let(:session) { double("ClioClient::Session") }
   let(:api) { double("ClioClient::Api::Base") }
   before { subject.stub(:api).and_return(api) }
-  
+
   describe "an integer field" do
     let(:params) { {"int" => "1"} }
 
@@ -69,6 +69,13 @@ describe ClioClient::Resource do
         api.should_receive(:create).with(to_params)
         subject.save
       end
+      context "and api returns false" do
+        it "should return the resource and leave the id blank" do
+          allow(api).to receive(:create) { false }
+          subject.save
+          expect(subject.id).to eq nil
+        end
+      end
     end
     context "when the record has an id" do
       it "makes a update call" do
@@ -76,7 +83,6 @@ describe ClioClient::Resource do
         subject.save
       end
     end
-
   end
 
   describe "#reload" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'support/test_resource'
 require 'support/inherited_resource'
 require 'support/dummy_endpoint'
 require 'support/resource_examples'
+require 'date' # Specs fail without
 
 require 'rspec'
 require 'rspec/core/shared_context'


### PR DESCRIPTION
We have been using this fix in production for a few weeks now, no issues. An additional benefit over the results discussed in #15: when a user attempts to add events to a calendar for which they do not have permissions, the Conflict error is raised with an understandable error message. This scenario was also causing the NoMethodError to be raised.